### PR TITLE
Added Parse Ruby library to Community Highlights

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -456,6 +456,10 @@ $(document).ready(function(){
 		title: "Parse Python Wrapper",
 		description: "A Python wrapper for the Parse.com API.",
 		url: "https://github.com/dgrtwo/ParsePy"
+	},{
+		title: "Parse Client in Ruby",
+		description: "An object-relational mapper and cloud code webhooks server.",
+		url: "https://github.com/modernistik/parse-stack"
 	}];
 
 	for (var i = 0; i < communityRepos.length; i++) {


### PR DESCRIPTION
Originally opened: https://github.com/parse-community/docs/issues/392

I updated the ‘Community Highlights’ section with a link to the Parse-Stack Ruby gem, a library that supports the latest Parse Server API while supporting ActiveModel-like interfaces.

Thanks