### PR TITLE
Removed blank section in php sdk

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,9 +279,6 @@ slug: Parse + Open Source
                     <p>Latest Downloads</p>
                 </div>
             </a>
-            <div class="repoLink blankRepoLink">
-                <p></p>
-            </div>
             <div class="repoButton">
                 <a href="//github.com/parse-community/parse-php-sdk" target="_blank">
                     <button class="outline">View on GitHub</button>


### PR DESCRIPTION
Removes a blank section in the php sdk and evens out it's row of sdks.  Looks like this was intended to normalize the size of the container (like for the 'Cloud Code' section) with it's surrounding sections. 

However in this case the surrounding sections are each 3 parts, whereas php has an extra 4th empty section, making it the odd man out.