### PR TITLE
Changed REST guide to a singular link

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,13 +398,11 @@ slug: Parse + Open Source
                 <img src="img/rest.svg" alt="" class="SDKLogo">
                 <h4>REST API</h4>
             </div>
-            <div class="repoLink expandableRepoLink">
-                <p>Guides</p>
-                <ul>
-                    <a href="//docs.parseplatform.org/rest/guide" target="_blank"><li>Parse Server REST API Guide</li></a>
-                    <a href="https://parse.com/docs/rest/guide" target="_blank"><li>Parse.com REST API Guide</li></a>
-                </ul>
-            </div>
+            <a href="//docs.parseplatform.org/rest/guide" target="_blank">
+                <div class="repoLink">
+                    <p>Guide</p>
+                </div>
+            </a>
         </div>
 
     </div>


### PR DESCRIPTION
The REST guide link currently drops down to show the current link at `docs.parseplatform.org` and the old `parse.com` guide. The later of which is no longer active. This replaces the drop down guide for the REST section with a singular link to the current guide.