### PR TITLE
Fix text wrapping issue on community highlights

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -800,11 +800,8 @@ section {
   .repo .repoDescription {
     background: #ffffff;
     border-top: 1px solid #E0E0EA;
-    border-bottom: 1px solid #E0E0EA;
-    height: 72px;
-    overflow: hidden;
+    height: auto;
     text-overflow: ellipsis;
-    border-bottom: 12px #ffffff solid;
     line-height: 24px;
     padding: 12px 16px; }
   .repo .repoButton {

--- a/css/main.scss
+++ b/css/main.scss
@@ -1006,12 +1006,8 @@ section{
     .repoDescription{
         background: $white;
         border-top: 1px solid $purpleBorder;
-        border-bottom: 1px solid $purpleBorder;
-        height: 72px; //24px line height * 2 + 12px padding * 2
-        overflow: hidden;
+        height: auto;
         text-overflow: ellipsis;
-        //hide overflowing text and limit to two lines
-        border-bottom: 12px $white solid;
         line-height: 24px;
         padding: 12px 16px;
     }


### PR DESCRIPTION
repoDescription now expands to fit the text, also removed unnecessary bottom border

__Before changes:__
<img width="934" alt="Screenshot 2019-03-10 at 17 54 48" src="https://user-images.githubusercontent.com/13188249/54089228-ac681580-435e-11e9-865a-a823084713eb.png">

__After changes:__
<img width="946" alt="Screenshot 2019-03-10 at 18 00 24" src="https://user-images.githubusercontent.com/13188249/54089229-ac681580-435e-11e9-8db2-6edd82dc65cf.png">