### PR TITLE
Remove Facebook Page Button

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,7 +9,6 @@
         <div class="socialLinks">
             <h5>Stay Connected</h5>
             <div class="socialIcons">
-                <a href="https://www.facebook.com/{{ site.facebook_username }}" target="_blank"><img src="/img/facebook.svg" alt="">
                 <a href="https://twitter.com/{{ site.twitter_username }}" target="_blank"><img src="/img/twitter.svg" alt=""></a>
                 <a href="https://github.com/{{ site.github_username }}" target="_blank"><img src="/img/github.svg" alt=""></a>
                 <a href="http://stackoverflow.com/tags/{{ site.stackoverflow_tag }}" target="_blank"><img src="/img/overflow.svg" alt=""></a>


### PR DESCRIPTION
This fixes #17: I have removed the link to the old Parse.com facebook page as this is no longer necessary.

I've tested the site in my local environment with the change and it looks fine, with the removal of the button not appearing to have any other knock on effects.