### PR TITLE
Remove gitter chat button

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,9 +12,6 @@
         <a href="//docs.parseplatform.org/parse-server/guide/" target="_blank">
             <button class="large">Get Started</button>
         </a>
-        <a href="https://gitter.im/ParsePlatform/Chat" target="_blank">
-            <button class="outline large">Gitter Chat</button>
-        </a>
         <a href="https://community.parseplatform.org" target="_blank">
             <button class="outline large">Community Forum</button>
         </a>


### PR DESCRIPTION
As discussed in [#5419](https://github.com/parse-community/parse-server/issues/5419) of the server repo, we have decided to close down the Gitter chat in favour of using stack overflow for code question and the community forum for strategy/implementation discussion.