### PR TITLE
Added help & communication section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ repository: parse-community/parse-community.github.io
 facebook_username: parseit
 twitter_username:  parseplatform
 github_username:   parse-community
-stackoverflow_tag: parse.com
+stackoverflow_tag: parse-platform
 serverfault_tag:   parse
 
 # Build settings

--- a/css/main.css
+++ b/css/main.css
@@ -834,7 +834,7 @@ section {
   width: 100%;
   max-width: 650px;
   margin: 0 auto;
-  height: 72px;
+  height: auto;
   background: rgba(14, 105, 161, 0.03);
   position: relative;
   border: none;
@@ -843,7 +843,6 @@ section {
     position: relative; }
     .repoList .repoTitle h4, .repoList .repoTitle p, .repoList .repoDescription h4, .repoList .repoDescription p, .repoList .repoInfo h4, .repoList .repoInfo p {
       text-overflow: ellipsis;
-      overflow: hidden;
       white-space: nowrap; }
   .repoList h4 {
     margin: 16px 0px 4px 0px;
@@ -865,10 +864,9 @@ section {
   .repoList .repoDescription {
     opacity: 0.6;
     margin: 0px;
+    padding-right: 24px;
     padding-left: 24px;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis; }
+    padding-bottom: 16px; }
     @media screen and (max-width: 600px) {
       .repoList .repoDescription {
         padding-left: 16px; } }

--- a/css/main.css
+++ b/css/main.css
@@ -869,7 +869,8 @@ section {
     padding-bottom: 16px; }
     @media screen and (max-width: 600px) {
       .repoList .repoDescription {
-        padding-left: 16px; } }
+        padding-left: 16px;
+        padding-right: 16px; } }
   .repoList .language {
     text-align: right;
     padding-right: 16px;

--- a/css/main.scss
+++ b/css/main.scss
@@ -1084,6 +1084,7 @@ section{
         padding-bottom: 16px;
         @media screen and (max-width: $smallWidth){
             padding-left: 16px;
+            padding-right: 16px;
         }
     }
     .language{

--- a/css/main.scss
+++ b/css/main.scss
@@ -1044,7 +1044,7 @@ section{
     width: 100%;
     max-width: 650px;
     margin: 0 auto;
-    height: 72px;
+    height: auto;
     background: $fadedBlue;
     position: relative;
     border: none;
@@ -1053,7 +1053,6 @@ section{
         position: relative;
         h4, p{
             text-overflow: ellipsis;
-            overflow: hidden;
             white-space: nowrap;
         }
     }
@@ -1081,9 +1080,8 @@ section{
         opacity: 0.6;
         margin: 0px;
         padding-left: 24px;
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
+        padding-right: 24px;
+        padding-bottom: 16px;
         @media screen and (max-width: $smallWidth){
             padding-left: 16px;
         }

--- a/index.html
+++ b/index.html
@@ -11,13 +11,13 @@ slug: Parse + Open Source
        <table>
          <tr class="repoList">
            <td>
-             <a href="https://stackoverflow.com/tags/{{ site.stackoverflow_tag }}"><h4>Stack Overflow <ins>parse-platform</ins> tag</h4><p class="repoDescription">Use for any code level questions related to the Parse Platform. Please also use other tags where appropriate, such as parse-server, parse-dashboard, parse-javascript-sdk and parse-cloud.</p></a>
+             <a href="https://stackoverflow.com/tags/{{ site.stackoverflow_tag }}"><h4>Stack Overflow <ins>parse-platform</ins> tag</h4><p class="repoDescription">Use for any code level questions related to the Parse Platform. Please also use other tags where appropriate, such as <ins>parse-server</ins>, <ins>parse-dashboard</ins>, <ins>parse-javascript-sdk</ins> and <ins>parse-cloud</ins>.</p></a>
            </td>
          </tr>
          <tr class="repoList">
            <td>
              <a href="https://serverfault.com/tags/{{ site.serverfault_tag }}"><h4>Sever Fault <ins>parse</ins> tag</h4><p class="repoDescription">
-               Use for questions related to the hosting of Parse Server.</p></a>
+               Use for questions related to the hosting & maintenance of Parse Server.</p></a>
            </td>
          </tr>
          <tr class="repoList">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ slug: Parse + Open Source
 <!-- Parse Server section -->
 <section class="parseServer" id="server">
     <h3>Parse Server and Dashboard</h3>
-    <h6>The REST server and dashboard to manage your data</h6>
+    <h6>The REST server and dashboard to manage your data.</h6>
     <div class="tableWrapper">
         <table></table>
     </div>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ slug: Parse + Open Source
 <!-- Help / Communication section -->
 <section class="communication" id="communication">
     <h3>Help & Communication</h3>
-    <h6>Find out our preferred channels of communication for help, issues and disscussion.</h6>
+    <h6>Find the preferred channels of communication for help, issues and disscussion.</h6>
     <div class="tableWrapper">
        <table>
          <tr class="repoList">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,15 @@ layout: default
 slug: Parse + Open Source
 ---
 
+<!-- Help / Communication section -->
+<section class="communication" id="communication">
+    <h3>Help & Communication</h3>
+    <h6>Find out our preferred channels of communication for help, issues and disscussion.</h6>
+    <div class="tableWrapper">
+       <table>
+         <tr class="repoList">
+           <td>
+             <a href=""><h4>Stack Overflow <ins>Parse-Platform</ins> tag</h4><p class="repoDescription">For code level questions related to any of the client SDKs.</p></a>
            </td>
          </tr>
          <tr class="repoList">

--- a/index.html
+++ b/index.html
@@ -6,30 +6,30 @@ slug: Parse + Open Source
 <!-- Help / Communication section -->
 <section class="communication" id="communication">
     <h3>Help & Communication</h3>
-    <h6>Find the preferred channels of communication for help, issues and disscussion.</h6>
+    <h6>Our preferred channels of communication for help, issues and disscussion.</h6>
     <div class="tableWrapper">
        <table>
          <tr class="repoList">
            <td>
-             <a href="https://stackoverflow.com/questions/tagged/parse-platform"><h4>Stack Overflow <ins>parse-platform</ins> tag</h4><p class="repoDescription">Use for any code level questions related to the Parse Platform.</p></a>
+             <a href="https://stackoverflow.com/tags/{{ site.stackoverflow_tag }}"><h4>Stack Overflow <ins>parse-platform</ins> tag</h4><p class="repoDescription">Use for any code level questions related to the Parse Platform. Please also use other tags where appropriate, such as parse-server, parse-dashboard, parse-javascript-sdk and parse-cloud.</p></a>
            </td>
          </tr>
          <tr class="repoList">
            <td>
-             <a href="https://stackoverflow.com/questions/tagged/parse-server"><h4>Stack Overflow <ins>parse-server</ins> tag</h4><p class="repoDescription">
-               For code level questions related to Parse Server.</p></a>
+             <a href="https://serverfault.com/tags/{{ site.serverfault_tag }}"><h4>Sever Fault <ins>parse</ins> tag</h4><p class="repoDescription">
+               Use for questions related to the hosting of Parse Server.</p></a>
            </td>
          </tr>
          <tr class="repoList">
            <td>
              <a href="//community.parseplatform.org"><h4>Community Forum</h4><p class="repoDescription">
-               For discussion relating to strategy and implementation.</p></a>
+               Use for discussion relating to strategy and implementation.</p></a>
            </td>
          </tr>
          <tr class="repoList">
            <td>
-             <a href="https://github.com/parse-community"><h4>Github Issues</h4><p class="repoDescription">
-               For reporting bugs and making pull requests for specific repos.</p></a>
+             <a href="https://github.com/{{ site.github_username }}"><h4>Github Issues</h4><p class="repoDescription">
+               Use for reporting bugs and making pull requests for specific repositories.</p></a>
            </td>
          </tr>
        </table>

--- a/index.html
+++ b/index.html
@@ -11,12 +11,12 @@ slug: Parse + Open Source
        <table>
          <tr class="repoList">
            <td>
-             <a href=""><h4>Stack Overflow <ins>Parse-Platform</ins> tag</h4><p class="repoDescription">For code level questions related to any of the client SDKs.</p></a>
+             <a href="https://stackoverflow.com/questions/tagged/parse-platform"><h4>Stack Overflow <ins>parse-platform</ins> tag</h4><p class="repoDescription">For code level questions related to any of the client SDKs, dashboard and more.</p></a>
            </td>
          </tr>
          <tr class="repoList">
            <td>
-             <a href=""><h4>Stack Overflow <ins>Parse-Server</ins> tag</h4><p class="repoDescription">
+             <a href="https://stackoverflow.com/questions/tagged/parse-server"><h4>Stack Overflow <ins>parse-server</ins> tag</h4><p class="repoDescription">
                For code level questions related to Parse Server.</p></a>
            </td>
          </tr>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ slug: Parse + Open Source
        <table>
          <tr class="repoList">
            <td>
-             <a href="https://stackoverflow.com/questions/tagged/parse-platform"><h4>Stack Overflow <ins>parse-platform</ins> tag</h4><p class="repoDescription">For code level questions related to any of the client SDKs, dashboard and more.</p></a>
+             <a href="https://stackoverflow.com/questions/tagged/parse-platform"><h4>Stack Overflow <ins>parse-platform</ins> tag</h4><p class="repoDescription">Use for any code level questions related to the Parse Platform.</p></a>
            </td>
          </tr>
          <tr class="repoList">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,30 @@ layout: default
 slug: Parse + Open Source
 ---
 
+           </td>
+         </tr>
+         <tr class="repoList">
+           <td>
+             <a href=""><h4>Stack Overflow <ins>Parse-Server</ins> tag</h4><p class="repoDescription">
+               For question relating to the hosting and deployment of Parse Server.</p></a>
+           </td>
+         </tr>
+         <tr class="repoList">
+           <td>
+             <a href="//community.parseplatform.org"><h4>Community Forum</h4><p class="repoDescription">
+               For discussion relating to strategy and implementation.</p></a>
+           </td>
+         </tr>
+         <tr class="repoList">
+           <td>
+             <a href="https://github.com/parse-community"><h4>Github Issues</h4><p class="repoDescription">
+               For reporting bugs and making pull requests for specific repos.</p></a>
+           </td>
+         </tr>
+       </table>
+   </div>
+</section><!-- Help / Communication section -->
+
 <!-- Parse Server section -->
 <section class="parseServer" id="server">
     <h3>Parse Server and Dashboard</h3>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ slug: Parse + Open Source
          <tr class="repoList">
            <td>
              <a href=""><h4>Stack Overflow <ins>Parse-Server</ins> tag</h4><p class="repoDescription">
-               For question relating to the hosting and deployment of Parse Server.</p></a>
+               For code level questions related to Parse Server.</p></a>
            </td>
          </tr>
          <tr class="repoList">


### PR DESCRIPTION
This aims to make it more clear for people where they can get help, report bugs and join in with strategy discussions etc.

As suggested by - [#5419](https://github.com/parse-community/parse-server/issues/5419) in the server repo.

To do:
- [x] Finalise links to stack overflow tags as these may be changing.
- [x] Change help links in the footer to reflect changes