### PR TITLE
Fix text wrapping

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -734,7 +734,8 @@ section {
     padding: 10px 16px;
     position: relative; }
     .repo .repoTitle h4 {
-      transition: 0.4s cubic-bezier(0.4, 0, 0.2, 1); }
+      transition: 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+      white-space: normal; }
     .repo .repoTitle p {
       margin: 0px;
       opacity: 0.45;

--- a/css/main.css
+++ b/css/main.css
@@ -844,13 +844,16 @@ section {
   .repoList h4 {
     margin: 16px 0px 4px 0px;
     font-size: 14px;
-    line-height: 16px;
+    line-height: 24px;
     font-family: 'alrightBold';
     color: #66637A;
-    padding-left: 24px; }
+    padding-left: 24px;
+    padding-right: 24px;
+    white-space: normal; }
     @media screen and (max-width: 600px) {
       .repoList h4 {
-        padding-left: 16px; } }
+        padding-left: 16px;
+        padding-right: 16px; } }
   .repoList .metadata {
     margin: 0px;
     opacity: 0.45;

--- a/css/main.css
+++ b/css/main.css
@@ -859,7 +859,11 @@ section {
     margin: 0px;
     opacity: 0.45;
     font-size: 14px;
-    font-family: "din"; }
+    font-family: "din";
+    padding-right: 8px; }
+    @media screen and (max-width: 480px) {
+      .repoList .metadata {
+        display: none; } }
     .repoList .metadata span {
       margin-right: 12px; }
   .repoList .repoDescription {
@@ -877,6 +881,9 @@ section {
     padding-right: 16px;
     top: 2px;
     position: relative; }
+    @media screen and (max-width: 540px) {
+      .repoList .language {
+        display: none; } }
   .repoList .repoInfo {
     height: 100%;
     right: 0px;

--- a/css/main.scss
+++ b/css/main.scss
@@ -1075,8 +1075,12 @@ section{
         opacity: 0.45;
         font-size: 14px;
         font-family: "din";
+        padding-right: 8px;
         span{
             margin-right: 12px;
+        }
+        @media screen and (max-width: $smallWidth){
+            display: none;
         }
     }
     .repoDescription{
@@ -1095,6 +1099,11 @@ section{
         padding-right: 16px;
         top: 2px;
         position: relative;
+
+        @media screen and (max-width: 540px){
+            display: none;
+        }
+
     }
     .repoInfo{
         height: 100%;

--- a/css/main.scss
+++ b/css/main.scss
@@ -1058,12 +1058,15 @@ section{
     h4{
         margin: 16px 0px 4px 0px;
         font-size: 14px;
-        line-height: 16px;
+        line-height: 24px;
         font-family: 'alrightBold';
         color: $purpleText;
         padding-left: 24px;
+        padding-right: 24px;
+        white-space: normal;
         @media screen and (max-width: $smallWidth){
             padding-left: 16px;
+            padding-right: 16px;
         }
     }
     .metadata{

--- a/css/main.scss
+++ b/css/main.scss
@@ -922,6 +922,7 @@ section{
         position: relative;
         h4{
             transition: 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+            white-space: normal;
         }
         p{
             margin: 0px;


### PR DESCRIPTION
This fixes the text wrapping on both `repoList repoTitle` and `repo repoTitle` so that text can be seen on small width displays.

Fixes #20.

These changes do create some issues in the `repoList` class for Parse Server adaptors but at least you can actually read all the text on mobile (I'll try and fix this).

__Before changes:__
<img width="211" alt="Screenshot 2019-03-24 at 20 45 45" src="https://user-images.githubusercontent.com/13188249/54885576-9174c580-4e75-11e9-817e-0fb26cc240cd.jpeg">
<img width="211" alt="Screenshot 2019-03-24 at 20 45 45" src="https://user-images.githubusercontent.com/13188249/54885615-1a8bfc80-4e76-11e9-9fd9-4a92b253ca0b.png">

__After changes:__
<img width="211" alt="Screenshot 2019-03-24 at 20 45 45" src="https://user-images.githubusercontent.com/13188249/54885570-84f06d00-4e75-11e9-8a0d-2f6c922e7cfe.jpeg">
<img width="211" alt="Screenshot 2019-03-24 at 20 46 35 1" src="https://user-images.githubusercontent.com/13188249/54885612-16f87580-4e76-11e9-8db6-2cdaaa495425.png">