### PR TITLE
Update Parse homepage nav

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
 <nav>
     <div class="container">
-        <a href="//"  target="_blank">
+        <a href="/">
             <img src="/img/logo.svg" alt="Parse logo" class="logo">
         </a>
         <ul>


### PR DESCRIPTION
Heya! 
Current link causes opening new blank page when user clicks to the Parse Logo,  but it expected to take you to the homepage.