### PR TITLE
Add digital climate strike banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,74 @@ layout: default
 slug: Parse + Open Source
 ---
 
+<script type="text/javascript">
+  var DIGITAL_CLIMATE_STRIKE_OPTIONS = {
+    /**
+     * Specify view cookie expiration. After initial view, widget will not be
+     * displayed to a user again until after this cookie expires. Defaults to
+     * one day.
+     */
+    cookieExpirationDays: 1, // @type {number}
+
+    /**
+     * Set the language of the widget. We currently support:
+     * 'en': English
+     * 'de': German
+     * 'es': Spanish
+     * 'cs': Czech
+     * 'fr': French
+     * 'nl': Dutch
+     * Defaults to null, which will obey the nagivator.language setting of the
+     * viewer's browser.
+     */
+     language: null, // @type {string}
+
+    /**
+     * Allow you to override the iFrame hostname. Defaults to https://assets.digitalclimatestrike.net
+     */
+    iframeHost: 'https://assets.digitalclimatestrike.net', // @type {string}
+
+    /**
+     * Prevents the widget iframe from loading Google Analytics. Defaults to
+     * false. (Google Analytics will also be disabled if doNotTrack is set on
+     * the user's browser.)
+     */
+    disableGoogleAnalytics: true, // @type {boolean}
+
+    /**
+     * Always show the widget, even when someone has closed the widget and set the cookie on their device.
+     * Useful for testing. Defaults to false.
+     */
+    alwaysShowWidget: false, // @type {boolean}
+
+    /**
+     * Automatically makes the widget full page. Defaults to false.
+     */
+    forceFullPageWidget: false, // @type {boolean}
+
+    /**
+    * For the full page widget, shows a close button "x" and hides the message about the site being
+    * available tomorrow. Defaults to false.
+    */
+    showCloseButtonOnFullPageWidget: true, // @type {boolean}
+
+    /**
+     * The date when the sticky footer widget should start showing on your web site.
+     * Note: the month is one integer less than the number of the month. E.g. 8 is September, not August.
+     * Defaults to new Date(2019, 7, 1) (August 1st, 2019).
+     */
+    footerDisplayStartDate: new Date(), //@ type {Date object}
+
+    /**
+     * The date when the full page widget should showing on your web site for 24 hours.
+     * Note: the month is one integer less than the number of the month. E.g. 8 is September, not August.
+     * Defaults to new Date(2019, 8, 20) (September 20th, 2019)
+     */
+    fullPageDisplayStartDate: new Date(2019, 8, 20), //@ type {Date object}
+  };
+</script>
+<script src="https://assets.digitalclimatestrike.net/widget.js" async></script>
+
 <!-- Help / Communication section -->
 <section class="communication" id="communication">
     <h3>Help & Communication</h3>


### PR DESCRIPTION
This PR adds the [Digital Climate Strike](https://digital.globalclimatestrike.net) banner.

The banner will appear at the bottom of the window and can be dismissed at anytime. After initial view, the banner will not be displayed to a user again until after the cookie expires (1 day).

On the 20th September it will change to a full page banner which is also dismissible, it will be present for 24 hours.

I've disabled the Google Analytics for the banner.