### PR TITLE
Removed links to the deleted community forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Parse Platform GitHub Pages
 
-[![Join The Conversation](https://img.shields.io/discourse/https/community.parseplatform.org/topics.svg)](https://community.parseplatform.org/c/parse-server)
 [![Backers on Open Collective](https://opencollective.com/parse-server/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/parse-server/sponsors/badge.svg)](#sponsors)
 [![License][license-svg]][license-link]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Parse Platform GitHub Pages
 
+[![Join The Conversation](https://img.shields.io/discourse/https/community.parseplatform.org/topics.svg)](https://community.parseplatform.org/c/parse-server)
 [![Backers on Open Collective](https://opencollective.com/parse-server/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/parse-server/sponsors/badge.svg)](#sponsors)
 [![License][license-svg]][license-link]

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,9 +12,6 @@
         <a href="//docs.parseplatform.org/parse-server/guide/" target="_blank">
             <button class="large">Get Started</button>
         </a>
-        <a href="https://community.parseplatform.org" target="_blank">
-            <button class="outline large">Community Forum</button>
-        </a>
       </h2>
       <h2>
           <span class="subheadSection "><img src="/img/stars.svg" alt="" class="icon"><span class="starCount"></span></span>

--- a/index.html
+++ b/index.html
@@ -22,12 +22,6 @@ slug: Parse + Open Source
          </tr>
          <tr class="repoList">
            <td>
-             <a href="//community.parseplatform.org"><h4>Community Forum</h4><p class="repoDescription">
-               Use for discussion relating to strategy and implementation.</p></a>
-           </td>
-         </tr>
-         <tr class="repoList">
-           <td>
              <a href="https://github.com/{{ site.github_username }}"><h4>Github Issues</h4><p class="repoDescription">
                Use for reporting bugs and making pull requests for specific repositories.</p></a>
            </td>


### PR DESCRIPTION
As discussed on twitter, the community forum has ben deleted and there is some work going on to pusblish a replacement.

Meanwhile it would be a good idea to remove the links to the deleted forum from the public website.